### PR TITLE
nodes.cpp zrobione

### DIFF
--- a/include/nodes.hpp
+++ b/include/nodes.hpp
@@ -19,7 +19,7 @@ enum class ReceiverType{
 class IPackageReceiver{
 public:
     virtual void receive_package(Package&& p) = 0;
-    virtual ElementID get_id() const { return id_;}
+    virtual ElementID get_id() const = 0;
     virtual IPackageStockpile::const_iterator  cbegin() const = 0;
     virtual IPackageStockpile::const_iterator cend() const = 0;
     virtual IPackageStockpile::const_iterator begin() const = 0;
@@ -37,8 +37,8 @@ private:
     std::unique_ptr<PackageQueue> d_;
 
 public:
-    Storehouse(ElementID id, std::unique_ptr<IPackageQueue> d = std::make_unique<PackageQueue> (PackageQueueType::FIFO));
-
+    Storehouse(ElementID id, std::unique_ptr<IPackageQueue> d);
+    ElementID get_id() const override {return id_;}
     void receive_package(Package&& p) override;
 
 
@@ -68,6 +68,8 @@ public:
     const_iterator begin() const {return preferences_.begin();}
     const_iterator end() const {return preferences_.end();}
 
+    virtual ~ReceiverPreferences() = default;
+
 private:
     ProbabilityGenerator gen;
 };
@@ -82,7 +84,7 @@ public:
     std::optional<Package>& get_sending_buffer() {return buffer_;}
 
 protected:
-    void push_package(Package&&);
+    void push_package(Package&& p);
 private:
     std::optional<Package> buffer_ = std::nullopt;
 };
@@ -114,8 +116,8 @@ public:
     void receive_package(Package&& p) override;
     ElementID get_id() const override {return id_;}
     void do_work(Time t);
-    TimeOffset get_processing_duration() const;
-    Time get_package_processing_start_time() const;
+    TimeOffset get_processing_duration() const {return offset;};
+    Time get_package_processing_start_time() const {return start_time;};
 
     virtual IPackageStockpile::const_iterator cbegin() const override {return queue->cbegin();}
     virtual IPackageStockpile::const_iterator cend() const override {return queue->cend();}

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -2,16 +2,16 @@
 
 //STOREHOUSE
 
-Storehouse::Storehouse(ElementID id, std::unique_ptr<IPackageStockpile> d) {
-
+Storehouse::Storehouse(ElementID id, std::unique_ptr<IPackageQueue> d = nullptr){
+    if(d == nullptr)
+    {
+        this->id_ = id;
+        d = std::make_unique<PackageQueue>(PackageQueueType::FIFO);
+    }
 }
 
 void Storehouse::receive_package(Package&& p) {
-
-}
-
-ElementID Storehouse::get_id() const {
-
+    d_->push(std::move(p));
 }
 
 
@@ -19,19 +19,34 @@ ElementID Storehouse::get_id() const {
 //ReceiverPreferences
 
 void ReceiverPreferences::add_receiver(IPackageReceiver* r) {
-
+    preferences_.insert(std::pair<IPackageReceiver*,double>(r, 1.0/double(preferences_.size())));
+    for(auto i = preferences_.begin(); i != preferences_.end(); i++)
+    {
+        i->second = 1.0/double(preferences_.size());
+    }
 }
 
 void ReceiverPreferences::remove_receiver(IPackageReceiver* r) {
-
+    preferences_.erase(r);
+    for(auto i = preferences_.begin(); i != preferences_.end(); i++)
+    {
+        i->second = 1.0/double(preferences_.size());
+    }
 }
 
 IPackageReceiver* ReceiverPreferences::choose_receiver() {
-
-}
-
-ReceiverPreferences::preferences_t ReceiverPreferences::get_preferences() const {
-
+    double lottery = gen();
+    for(auto i = preferences_.begin(); i!=preferences_.end(); i++){
+        if (lottery < i->second)
+        {
+            return i->first;
+        }
+        else
+        {
+            lottery -= i->second;
+        }
+    }
+    throw std::invalid_argument("reached end of function choose_receiver: probably empty list");
 }
 
 
@@ -42,53 +57,57 @@ void PackageSender::send_package() {
 
 }
 
-std::optional<Package>& PackageSender::get_sending_buffer() const {
 
-}
-
-void PackageSender::push_package(Package&&) {
-
+void PackageSender::push_package(Package&& p) {
+    buffer_.emplace(std::move(p));
 }
 
 //RAMP
-Ramp::Ramp(ElementID id, TimeOffset di) {
-
-}
 
 void Ramp::deliver_goods(Time t) {
-
+    push_package(Package());
+    if(delivery_time_ + offset_ <= t)
+    {
+        send_package();
+        delivery_time_ = t;
+    }
 }
 
-TimeOffset Ramp::get_delivery_interval() const {
 
-}
-
-ElementID Ramp::get_id() const {
-
-}
 
 //WORKER
 
-Worker::Worker(ElementID id, TimeOffset pd, std::unique_ptr<IPackageQueue>) {
-
+Worker::Worker(ElementID id, TimeOffset pd, std::unique_ptr<IPackageQueue> q) {
+    PackageSender();
+    this->id_ = id;
+    this->offset = pd;
+    this->queue = std::move(q);
+    this->start_time = 0;
 }
 
 void Worker::receive_package(Package&& p) {
-
-}
-
-ElementID Worker::get_id() const {
-
+    if(!get_sending_buffer())
+    {
+        queue->push(std::move(p));
+    }
+    else
+    {
+        queue->push(std::move(p));
+        push_package(queue->pop());
+    }
 }
 
 void Worker::do_work(Time t) {
-
+    if(!current_package && queue)
+    {
+        current_package.emplace(queue->pop());
+        start_time = t;
+    }
+    if(current_package && t + 1 - start_time >= offset)
+    {
+        push_package(std::move(current_package.value()));
+        current_package.reset();
+        start_time = 0;
+    }
 }
 
-TimeOffset Worker::get_processing_duration() const{
-
-}
-
-Time Worker::get_package_processing_start_time() const{
-
-}


### PR DESCRIPTION
Funkcje zaimplementowane, wywaliłem z nodes.cpp funkcje typu get_id() czy get_preferences() bo to jest implementacja jednolinijkowa i to się robi w nodes.hpp, dodałem w nodes.hpp destruktory wirtualne w klasach bazowych. 

P.S. plis nie każcie mi już kurwa patrzeć na ten przedmiot i ten projekt :c